### PR TITLE
Stop generating separate version check for features

### DIFF
--- a/bundles/org.eclipse.cbi.p2repo.analyzers-bundle/src/org/eclipse/cbi/p2repo/analyzers/BuildRepoTests.java
+++ b/bundles/org.eclipse.cbi.p2repo.analyzers-bundle/src/org/eclipse/cbi/p2repo/analyzers/BuildRepoTests.java
@@ -313,7 +313,6 @@ public class BuildRepoTests {
 
         if (referenceRepoToTest != null) {
             iuVersioncheck.checkIUVersionsToReference();
-            iuVersioncheck.checkIUVersionsToReferenceForFeatures();
         }
 
         if (featureNameFailures || bundleNameFailures || providerNamesFailure || licenseConsistencyFailure || greedyCheck) {

--- a/bundles/org.eclipse.cbi.p2repo.analyzers-bundle/src/templateFiles/indexmain.html
+++ b/bundles/org.eclipse.cbi.p2repo.analyzers-bundle/src/templateFiles/indexmain.html
@@ -51,11 +51,6 @@
             </dt>
             <dd>This report lists jar files that fail "jarsigner -verify" in a serious way (more than simply "not signed", but more likely "not valid" or "tampered with". Indicates a project build issue. Re-processing or re-signing jars?</dd>
             <dt>
-                <a href="reports/versionChecksFeatures.html">Feature versions compared to reference repository</a>
-            </dt>
-            <dd>This report goes through the repo, looking for "groups" (features) and tabulates the comparison to reference repository. 
-            The comparisons to pay most attention to are those that "decrease" from last release, to the current release.</dd>
-            <dt>
                 <a href="reports/versionChecks.html">Bundle versions compared to reference repository</a>
             </dt>
             <dd>Similar to the "Feature versions" report, this report scans the repo, looking for "non-groups" (bundles) and tabulates the comparison to reference repository. 

--- a/bundles/org.eclipse.cbi.p2repo.analyzers-bundle/src/templateFiles/indexmainpresign.html
+++ b/bundles/org.eclipse.cbi.p2repo.analyzers-bundle/src/templateFiles/indexmainpresign.html
@@ -50,11 +50,6 @@
             <dt>Unsigned bundles and features</dt>
             <dd>(pending)</dd>
             <dt>
-                <a href="reports/versionChecksFeatures.html">Feature versions compared to reference repository</a>
-            </dt>
-            <dd>This report goes through the repo, looking for "groups" (features) and tabulates the comparison to reference repository. 
-            The comparisons to pay most attention to are those that "decrease" from last release, to the current release.</dd>
-            <dt>
                 <a href="reports/versionChecks.html">Bundle versions compared to reference repository</a>
             </dt>
             <dd>Similar to the "Feature versions" report, this report scans the repo, looking for "non-groups" (bundles) and tabulates the comparison to reference repository. 

--- a/bundles/org.eclipse.cbi.p2repo.analyzers.junit/src/org/eclipse/cbi/p2repo/analyzers/RepositoryTest.java
+++ b/bundles/org.eclipse.cbi.p2repo.analyzers.junit/src/org/eclipse/cbi/p2repo/analyzers/RepositoryTest.java
@@ -129,7 +129,6 @@ public class RepositoryTest {
 		IUVersionCheckToReference checker = new IUVersionCheckToReference(CONF_FROM_SYSTEM_PROPERTIES);
 		if (configureChecker(checker) && refRepoDir != null) {
 			assertFalse("Correct version changes", !checker.checkIUVersionsToReference());
-			assertTrue("Correct version changes for features", !checker.checkIUVersionsToReferenceForFeatures());
 		}
 	}
 


### PR DESCRIPTION
As it can be seen at
https://download.eclipse.org/eclipse/downloads/drops4/I20230118-1800/buildlogs/reporeports/reports/versionChecks.html "Bundle versions compared to reference repository" already reports feature versions so there is no need for separate one like https://download.eclipse.org/eclipse/downloads/drops4/I20230118-1800/buildlogs/reporeports/reports/versionChecksFeatures.html