### PR TITLE
Fix license file check in features

### DIFF
--- a/bundles/org.eclipse.cbi.p2repo.analyzers.common/src/org/eclipse/cbi/p2repo/analyzers/common/checker/impl/LayoutChecker.java
+++ b/bundles/org.eclipse.cbi.p2repo.analyzers.common/src/org/eclipse/cbi/p2repo/analyzers/common/checker/impl/LayoutChecker.java
@@ -72,9 +72,7 @@ public class LayoutChecker implements IArtifactChecker {
 	}
 
 	private void processArchive(File file, List<String> expected, CheckReport report) {
-		ZipFile zip = null;
-		try {
-			zip = new ZipFile(file, ZipFile.OPEN_READ);
+		try (ZipFile zip = new ZipFile(file, ZipFile.OPEN_READ);){
 			Map<String, String> found = new HashMap<>();
 			for (String string : expected) {
 				found.put(string, null);
@@ -103,14 +101,6 @@ public class LayoutChecker implements IArtifactChecker {
 			}
 		} catch (IOException e) {
 			e.printStackTrace();
-		} finally {
-			if (zip != null) {
-				try {
-					zip.close();
-				} catch (IOException e) {
-					// ignore
-				}
-			}
 		}
 	}
 }

--- a/bundles/org.eclipse.cbi.p2repo.analyzers.common/src/org/eclipse/cbi/p2repo/analyzers/common/checker/impl/LayoutChecker.properties
+++ b/bundles/org.eclipse.cbi.p2repo.analyzers.common/src/org/eclipse/cbi/p2repo/analyzers/common/checker/impl/LayoutChecker.properties
@@ -28,4 +28,4 @@ default.binary.zip = ^.*/META-INF/MANIFEST\.MF, \
 
 # default layout for a feature
 default.feature = license\.html, \
-    (edl-v10\.html|epl-v10\.html|epl-v2\.0\.html)
+    (edl-v10\.html|epl-v10\.html|epl-v2\.0\.html|epl-2\.0\.html)


### PR DESCRIPTION
As visible in
https://download.eclipse.org/eclipse/downloads/drops4/I20230510-1800/buildlogs/reporeports/reports/layoutCheck.txt there are many:
"Missing (edl-v10.html|epl-v10.html|epl-v2.0.html) in file: org.eclipse.core.runtime.feature_1.4.0.v20230510-1240.jar" . Ironically enough, the shared license has been epl-2.0.html for the last 6 years https://github.com/eclipse-cbi/epl-license-feature/blob/main/org.eclipse.license/epl-2.0.html .