### PR TITLE
Support general remote p2-repositories as referenceRepo

### DIFF
--- a/bundles/org.eclipse.cbi.p2repo.analyzers-bundle/src/org/eclipse/cbi/p2repo/analyzers/BuildRepoTests.java
+++ b/bundles/org.eclipse.cbi.p2repo.analyzers-bundle/src/org/eclipse/cbi/p2repo/analyzers/BuildRepoTests.java
@@ -63,7 +63,7 @@ public class BuildRepoTests {
      */
     private static boolean               outputDirectoryInitialized;
     private Path                         directoryToCheck;
-    private Path                         referenceDirectoryToCheck;
+    private URI                          referenceRepositoryToCheck;
     private Path                         tempWorkingDir;
     private boolean                      failuresOccurred = false;
     private ReportWriter                 reportWriter;
@@ -257,14 +257,14 @@ public class BuildRepoTests {
 
     private void doRepoTests() throws IOException, ProvisionException, OperationCanceledException {
         URI repoToTest = getDirectoryToCheck().toUri();
-        URI referenceRepoToTest = null;
-        if (getDirectoryToCheckForReference() != null) {
-            Path refRepoToCheck = getDirectoryToCheckForReference();
-            if (Files.exists(refRepoToCheck)) {
-                referenceRepoToTest = refRepoToCheck.toUri();
-            } else {
+        URI referenceRepoToTest = getRepositoryToCheckForReference();
+        if (referenceRepoToTest != null) {
+            try (InputStream in = referenceRepoToTest.toURL().openStream()) {
+                // Just check if URL target exists
+            } catch (Exception e) {
+                referenceRepoToTest = null;
                 System.out.println("WARNING: the reference repository was found not to exist. No check done.");
-                System.out.println("         referenceRepo: " + getDirectoryToCheckForReference());
+                System.out.println("         referenceRepo: " + getRepositoryToCheckForReference());
             }
         }
 
@@ -357,15 +357,15 @@ public class BuildRepoTests {
         // this.failuresOccurred = failuresOccurred;
     }
 
-    public Path getDirectoryToCheckForReference() {
-        if (referenceDirectoryToCheck == null) {
-            referenceDirectoryToCheck = configurations.getReferenceRepoDir();
+    public URI getRepositoryToCheckForReference() {
+        if (referenceRepositoryToCheck == null) {
+            referenceRepositoryToCheck = configurations.getReferenceRepo();
         }
-        return referenceDirectoryToCheck;
+        return referenceRepositoryToCheck;
     }
 
-    public void setDirectoryToCheckForReference(Path referenceDirectoryToCheck) {
-        this.referenceDirectoryToCheck = referenceDirectoryToCheck;
+    public void setRepositoryToCheckForReference(URI referenceRepositoryToCheck) {
+        this.referenceRepositoryToCheck = referenceRepositoryToCheck;
     }
 
     public boolean copyTemplateForIndexFile(String filename) throws IOException {

--- a/bundles/org.eclipse.cbi.p2repo.analyzers-bundle/src/org/eclipse/cbi/p2repo/analyzers/RepoTestsConfiguration.java
+++ b/bundles/org.eclipse.cbi.p2repo.analyzers-bundle/src/org/eclipse/cbi/p2repo/analyzers/RepoTestsConfiguration.java
@@ -5,8 +5,10 @@ package org.eclipse.cbi.p2repo.analyzers;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import org.eclipse.cbi.p2repo.analyzers.common.reporter.IP2RepositoryAnalyserConfiguration;
 
@@ -23,7 +25,7 @@ public final class RepoTestsConfiguration implements IP2RepositoryAnalyserConfig
     public static final String REPO_URL_PARAM           = "repoURLToTest";
     public static final String REFERENCE_REPO_URL_PARAM = "repoURLForReference";
 
-    private final Path         referenceRepoDir;
+    private final URI          referenceRepo;
     private final Path         reportOutputDir;
     private final Path         reportRepoDir;
     private final Path         tempWorkingDir;
@@ -33,13 +35,13 @@ public final class RepoTestsConfiguration implements IP2RepositoryAnalyserConfig
     /**
      * @param reportRepoDir
      * @param reportOutputDir
-     * @param referenceRepoDir
+     * @param referenceRepo
      * @param tempWorkingDir
      */
-    public RepoTestsConfiguration(Path reportRepoDir, Path reportOutputDir, Path referenceRepoDir, Path tempWorkingDir) {
+    public RepoTestsConfiguration(Path reportRepoDir, Path reportOutputDir, URI referenceRepo, Path tempWorkingDir) {
         this.reportRepoDir = reportRepoDir;
         this.reportOutputDir = reportOutputDir;
-        this.referenceRepoDir = referenceRepoDir;
+        this.referenceRepo = referenceRepo;
         this.tempWorkingDir = tempWorkingDir;
     }
 
@@ -73,8 +75,8 @@ public final class RepoTestsConfiguration implements IP2RepositoryAnalyserConfig
         this.repoURLForReference = repoURLForReference;
     }
 
-    public Path getReferenceRepoDir() {
-        return referenceRepoDir;
+    public URI getReferenceRepo() {
+        return referenceRepo;
     }
 
     @Override
@@ -96,17 +98,30 @@ public final class RepoTestsConfiguration implements IP2RepositoryAnalyserConfig
     }
 
     public static RepoTestsConfiguration createFromSystemProperties() {
-        String repoDir = System.getProperty(REPORT_REPO_DIR_PARAM, null);
-        if (repoDir == null || repoDir.isEmpty()) {
-            repoDir = System.getenv(REPORT_REPO_DIR_PARAM);
+        Path repoDir = getSystemOrEnvValue(REPORT_REPO_DIR_PARAM).orElse(null);
+        Path outDir = getSystemOrEnvValue(REPORT_OUTPUT_DIR_PARAM).orElse(null);
+        Path tmpDir = Path.of(System.getProperty("java.io.tmpdir"));
+        URI referenceRepo = parsePathToURI(System.getProperty(REFERENCE_REPO_PARAM, null));
+        return new RepoTestsConfiguration(repoDir, outDir, referenceRepo, tmpDir);
+    }
+
+    private static Optional<Path> getSystemOrEnvValue(String key) {
+        String value = System.getProperty(key);
+        if (value == null || value.isEmpty()) {
+            value = System.getenv(key);
         }
-        String outDir = System.getProperty(REPORT_OUTPUT_DIR_PARAM, null);
-        if (outDir == null || outDir.isEmpty()) {
-            outDir = System.getenv(REPORT_OUTPUT_DIR_PARAM);
+        return Optional.ofNullable(value).map(Path::of);
+    }
+
+    private static URI parsePathToURI(String refRepoDir) {
+        try {
+            URI referenceRepo = new URI(refRepoDir);
+            if (referenceRepo.getScheme() != null) {
+                return referenceRepo;
+            } // a null scheme was probably a UNIX path
+        } catch (URISyntaxException e) { // assume file path
         }
-        String tmpDir = System.getProperty("java.io.tmpdir");
-        String refRepoDir = System.getProperty(REFERENCE_REPO_PARAM, null);
-        return new RepoTestsConfiguration(Path.of(repoDir), Path.of(outDir), Path.of(refRepoDir), Path.of(tmpDir));
+        return Path.of(refRepoDir).toUri();
     }
 
     @Override

--- a/bundles/org.eclipse.cbi.p2repo.analyzers-bundle/src/org/eclipse/cbi/p2repo/analyzers/jars/SignerTest.java
+++ b/bundles/org.eclipse.cbi.p2repo.analyzers-bundle/src/org/eclipse/cbi/p2repo/analyzers/jars/SignerTest.java
@@ -54,7 +54,7 @@ public class SignerTest extends TestJars {
         useJarsigner = "true".equals(System.getProperty("useJarsigner"));
         try {
             artifactRepository = (IFileArtifactRepository) TestRepo.getAgent().getService(IArtifactRepositoryManager.class)
-                    .loadRepository(configurations.getReportRepoDir().toUri(), new NullProgressMonitor());
+                    .loadRepository(configurations.getReportRepoURI(), new NullProgressMonitor());
         } catch (ProvisionException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/bundles/org.eclipse.cbi.p2repo.analyzers.junit/src/org/eclipse/cbi/p2repo/analyzers/RepositoryTest.java
+++ b/bundles/org.eclipse.cbi.p2repo.analyzers.junit/src/org/eclipse/cbi/p2repo/analyzers/RepositoryTest.java
@@ -43,7 +43,7 @@ public class RepositoryTest {
 	private static final Set<String> SKIPPED_CHECKER = new HashSet<>();
 	private static Path dirToTest;
 	private static URI repoToTest;
-	private static Path refRepoDir;
+	private static URI refRepo;
 
 	@BeforeClass
 	public static final void beforeClass() {
@@ -59,7 +59,7 @@ public class RepositoryTest {
 		}
 		dirToTest = directoryToCheck;
 		repoToTest = directoryToCheck .toUri();
-		refRepoDir = tests.getDirectoryToCheckForReference();
+		refRepo = tests.getRepositoryToCheckForReference();
 
 		String skipCheckerProp = System.getProperty(SKIP_CHECKER_PROP_NAME);
 		if (skipCheckerProp != null) {
@@ -128,7 +128,7 @@ public class RepositoryTest {
 	public void testIUVersionCheckToReference()
 			throws ProvisionException, OperationCanceledException, URISyntaxException, IOException {
 		IUVersionCheckToReference checker = new IUVersionCheckToReference(CONF_FROM_SYSTEM_PROPERTIES);
-		if (configureChecker(checker) && refRepoDir != null) {
+		if (configureChecker(checker) && refRepo != null) {
 			assertFalse("Correct version changes", !checker.checkIUVersionsToReference());
 		}
 	}

--- a/features/org.eclipse.cbi.p2repo.analyzers.feature/feature.xml
+++ b/features/org.eclipse.cbi.p2repo.analyzers.feature/feature.xml
@@ -20,6 +20,10 @@
       %license
    </license>
 
+   <requires>
+      <import feature="org.eclipse.equinox.p2.core.feature" version="1.7" match="greaterOrEqual"/>
+   </requires>
+
    <plugin
          id="org.eclipse.cbi.p2repo.analyzers"
          version="0.0.0"/>

--- a/releng/org.eclipse.cbi.p2repo.analyzers.product/org.eclipse.cbi.p2repo.analyzers.product
+++ b/releng/org.eclipse.cbi.p2repo.analyzers.product/org.eclipse.cbi.p2repo.analyzers.product
@@ -28,10 +28,6 @@
 
    <plugins>
       <plugin id="org.eclipse.equinox.event"/>
-      <plugin id="org.eclipse.equinox.security.macosx" fragment="true"/>
-      <plugin id="org.eclipse.equinox.security.win32" fragment="true"/>
-      <plugin id="org.eclipse.equinox.simpleconfigurator"/>
-      <plugin id="org.eclipse.osgi.compatibility.state" fragment="true"/>
    </plugins>
 
    <features>

--- a/tests/org.eclipse.cbi.p2repo.analyzers.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.cbi.p2repo.analyzers.tests/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Require-Bundle: org.eclipse.equinox.common;bundle-version="3.6.200",
  org.junit;bundle-version="4.8.0",
  org.eclipse.cbi.p2repo.analyzers,
  org.eclipse.equinox.p2.core,
+ org.eclipse.equinox.p2.transport.ecf,
  org.eclipse.cbi.p2repo.analyzers.common
 Bundle-Vendor: %Bundle-Vendor
 Automatic-Module-Name: org.eclipse.cbi.p2repo.analyzers.tests

--- a/tests/org.eclipse.cbi.p2repo.analyzers.tests/src/org/eclipse/cbi/p2repo/analyzers/reports/ReportTest.java
+++ b/tests/org.eclipse.cbi.p2repo.analyzers.tests/src/org/eclipse/cbi/p2repo/analyzers/reports/ReportTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 public class ReportTest {
 
 	static Path data;
+	static URI repo;
 
 	@BeforeClass
 	public static void download() throws Exception {
@@ -24,6 +25,7 @@ public class ReportTest {
 			data = "file".equals(self.getProtocol()) ? Path.of(self.toURI()).resolve("data")
 					: Files.createTempDirectory("report-test");
 
+			repo = URI.create("https://download.eclipse.org/oomph/updates/latest");
 			URL sampleSite = new URI("https://download.eclipse.org/oomph/updates/latest/org.eclipse.oomph.site.zip").toURL();
 			try (ZipInputStream in = new ZipInputStream(sampleSite.openStream())) {
 				ZipEntry entry;
@@ -45,7 +47,7 @@ public class ReportTest {
 
 	@Test
 	public void testReportGenerator() {
-		RepoTestsConfiguration configuration = new RepoTestsConfiguration(data, data.resolve("report"), data, null);
+		RepoTestsConfiguration configuration = new RepoTestsConfiguration(data, data.resolve("report"), repo, null);
 		new BuildRepoTests(configuration).execute();
 	}
 }


### PR DESCRIPTION
To implement support for general p2-repositories (also remote ones) as `referenceRepo` the internal modeling just have to be changed from `Path` to `URI` and it has to be made sure that the bundle `org.eclipse.equinox.p2.transport.ecf` is included into the runtime.
The latter is done by requiring the `org.eclipse.equinox.p2.core.feature`.

Currently this also includes the changes of the PRs
- [x] https://github.com/eclipse-cbi/p2repo-analyzers/pull/54
- [x] https://github.com/eclipse-cbi/p2repo-analyzers/pull/58

and is therefore a draft.