### PR TITLE
[Build] Reduce archive size and number of retained archives

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
   }
 
   options {
-    buildDiscarder(logRotator(numToKeepStr: '10'))
+    buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '2'))
     disableConcurrentBuilds()
   }
 
@@ -124,7 +124,7 @@ pipeline {
       post {
         always {
             junit '**/target/surefire-reports/TEST-*.xml'
-            archiveArtifacts artifacts: 'releng/org.eclipse.cbi.p2repo.analyzers.repository/target/**, releng/org.eclipse.cbi.p2repo.analyzers.product/target/**, releng/org.eclipse.cbi.p2repo.analyzers.parent/promotion/**'
+            archiveArtifacts artifacts: 'releng/org.eclipse.cbi.p2repo.analyzers.repository/target/repository/**, releng/org.eclipse.cbi.p2repo.analyzers.product/target/products/*,'
         }
       }
     }


### PR DESCRIPTION
Archive only the tools repository content and the compressed products artifacts.
Besides the target content of the promotion project, this skips for example the exploded products and the zipped repository.

Should resolve:
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/7353#note_6864068

Furthermore the [ci.eclipse.org/cbi/job/p2repo-analyzers](https://ci.eclipse.org/cbi/job/p2repo-analyzers/configure) Jenkins Multi-branch pipeline job should be configured to retain less old items, probably zero or one, in order to clean-up old PRs quicker:

<img width="500" alt="grafik" src="https://github.com/user-attachments/assets/ad56fd11-b053-4d98-951b-49980e0e207d" />


